### PR TITLE
Guarded action sets, input name modification and allow default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,11 +1003,3 @@ method. These decorators are important for recording the executed actions to obs
 
 Lastly, `verbose_action_exception` (for `run`) or `async_verbose_action_exception` (for `async_run`) should be added 
 as well to prettify errors.
-
-# TODO
-- [x] as output for typed actions/condtions
-- [x] as guarded for action set
-- [x] guarded with `as_input` and `as_output`
-- [x] optional type as input
-- [x] optional as output
-- [x] return generator as output type

--- a/README.md
+++ b/README.md
@@ -969,3 +969,11 @@ method. These decorators are important for recording the executed actions to obs
 
 Lastly, `verbose_action_exception` (for `run`) or `async_verbose_action_exception` (for `async_run`) should be added 
 as well to prettify errors.
+
+# TODO
+- [x] as output for typed actions/condtions
+- [x] as guarded for action set
+- [x] guarded with `as_input` and `as_output`
+- [ ] optional type as input
+- [ ] optional as output
+- [ ] return generator as output type

--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ are optional.
 assert 5 == SumValuesAndRound()(x=1.9, y=3.1)
 ```
 
+##### Default values
+
+```
+class SumValuesAndRound(TypedAction):
+    def __call__(self, x: float, y: float = 1.0) -> str:
+        return int(x + y)
+
+assert 2.2 == SumValuesAndRound().run_with_data(x=1.2)
+```
+
 ##### Retry
 `TypedAction` and `TypedCondition` can be configured to retry the execution of the action if they fail.
 
@@ -255,6 +265,16 @@ Sometimes it's necessary to change the output signature of the actions "on the f
 ```
 my_typed_action.output_as(key="x_doubled", type_=MyNumber)
 my_typed_action.output_as(key="different_key")
+```
+
+##### Changing input signature
+
+```
+class MyAction:
+    def __call__(self, x: int) -> int:
+        ...
+        
+MyAction().input_as(x="different_input").run_with_data(different_input=3)
 ```
 
 #### OnActionDataSubField
@@ -381,6 +401,20 @@ is equal to
 ```
 ActionSet([Action1(), Action2(), Action3()])
 ```
+
+##### GuardedActionSet
+It can be generated from the `ActionSet` by using `as_guarded` method. This is useful when you want to ensure that 
+the action set will use only specified fields and "return" (=propagate further) only desired fields.
+
+```
+ActionSet([Action1(), Action2(), Action3()]).as_guarded()
+    .with_inputs("a", "b", new_c_name="old_c_name"),
+    .with_outputs("c", "d", new_e_name="old_e_name", new_f_name="old_f_name"),
+).run_with_data(a=1, b=2, old_c_name=3, will_be_ignored=4)
+```
+
+Result action data will contain only "c", "d", "new_e_name" and "new_f_name" keys.
+
 
 ##### EventSet
 
@@ -974,6 +1008,6 @@ as well to prettify errors.
 - [x] as output for typed actions/condtions
 - [x] as guarded for action set
 - [x] guarded with `as_input` and `as_output`
-- [ ] optional type as input
-- [ ] optional as output
-- [ ] return generator as output type
+- [x] optional type as input
+- [x] optional as output
+- [x] return generator as output type

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ my_typed_action.output_as(key="different_key")
 ##### Changing input signature
 
 ```
-class MyAction:
+class MyAction(TypedAction):
     def __call__(self, x: int) -> int:
         ...
         

--- a/orinoco/action.py
+++ b/orinoco/action.py
@@ -361,7 +361,7 @@ class GuardedActionSet(Action):
         return action_data
 
     @staticmethod
-    def _get_additive_signatures(action_data: ActionDataT, keys: List[str]) -> List[Signature]:
+    def _get_remaining_signatures(action_data: ActionDataT, keys: List[str]) -> List[Signature]:
         return [signature for signature in action_data.signatures if signature.key not in keys]
 
     @property

--- a/orinoco/action.py
+++ b/orinoco/action.py
@@ -330,7 +330,7 @@ class GuardedActionSet(Action):
             partial(self._remove_keys, desired_keys=self._input_keys),
             partial(self._rename_keys, keys=self.renamed_inputs),
             self.action_set.run,
-            partial(self._remove_keys, desired_keys=self._output_keys),
+            partial(self._remove_keys, keys_to_keep=self._output_keys),
             partial(self._rename_keys, keys=self.renamed_outputs),
         )(action_data)
 

--- a/orinoco/action.py
+++ b/orinoco/action.py
@@ -345,7 +345,7 @@ class GuardedActionSet(Action):
         return self
 
     @classmethod
-    def _remove_keys(cls, action_data: ActionDataT, desired_keys: List[str]) -> ActionDataT:
+    def _remove_keys(cls, action_data: ActionDataT, keys_to_keep: List[str]) -> ActionDataT:
         if not desired_keys:
             return action_data.evolve_self(data=tuple())
 

--- a/orinoco/action.py
+++ b/orinoco/action.py
@@ -350,7 +350,7 @@ class GuardedActionSet(Action):
             return action_data.evolve_self(data=tuple())
 
         return action_data.remove_many(
-            searched_signatures=cls._get_additive_signatures(action_data, keys_to_keep),
+            searched_signatures=cls._get_remaining_signatures(action_data, keys_to_keep),
             exact_match=False,
             ignore_non_existent=False,
         )

--- a/orinoco/action.py
+++ b/orinoco/action.py
@@ -327,7 +327,7 @@ class GuardedActionSet(Action):
 
     def run(self, action_data: ActionDataT) -> ActionDataT:
         return compose(
-            partial(self._remove_keys, desired_keys=self._input_keys),
+            partial(self._remove_keys, keys_to_keep=self._input_keys),
             partial(self._rename_keys, keys=self.renamed_inputs),
             self.action_set.run,
             partial(self._remove_keys, keys_to_keep=self._output_keys),

--- a/orinoco/action.py
+++ b/orinoco/action.py
@@ -346,7 +346,7 @@ class GuardedActionSet(Action):
 
     @classmethod
     def _remove_keys(cls, action_data: ActionDataT, keys_to_keep: List[str]) -> ActionDataT:
-        if not desired_keys:
+        if not keys_to_keep:
             return action_data.evolve_self(data=tuple())
 
         return action_data.remove_many(

--- a/orinoco/action.py
+++ b/orinoco/action.py
@@ -350,7 +350,7 @@ class GuardedActionSet(Action):
             return action_data.evolve_self(data=tuple())
 
         return action_data.remove_many(
-            searched_signatures=cls._get_additive_signatures(action_data, desired_keys),
+            searched_signatures=cls._get_additive_signatures(action_data, keys_to_keep),
             exact_match=False,
             ignore_non_existent=False,
         )

--- a/orinoco/condition.py
+++ b/orinoco/condition.py
@@ -80,7 +80,6 @@ class Condition(Action, ABC):
             format_dict = {
                 k: action_data.get_by_key(k, default=self.DEFAULT_FORMAT_VALUE) for k in fail_message_format_args
             }
-            print(format_dict)
             fail_message = fail_message.format(**format_dict)
         raise self.error_cls(
             "{}{} failed: {}".format("not " if self.is_inverted else "", self.__class__.__name__, fail_message)

--- a/orinoco/entities.py
+++ b/orinoco/entities.py
@@ -2,7 +2,7 @@ import abc
 from functools import partial
 from typing import Dict, Any, Optional, Set, Type, List, Tuple, Sequence, ClassVar, Generic, Awaitable, Union
 
-from pydantic import Field
+from pydantic import Field, validator
 
 from orinoco.exceptions import SearchError, NothingFound, FoundMoreThanOne, AlreadyRegistered
 from orinoco.helpers import initialize
@@ -26,7 +26,7 @@ class ImmutableEvolvableModel(ImmutableEvolvableModelT, abc.ABC):
 
 
 class Signature(Generic[T], ImmutableEvolvableModel, SignatureT[T]):
-    type_: Optional[Type[T]] = None
+    type_: Optional[Any] = None
     tags: Set[str] = Field(default_factory=set)
     key: Optional[str] = None
 
@@ -51,6 +51,10 @@ class Signature(Generic[T], ImmutableEvolvableModel, SignatureT[T]):
     def __class_getitem__(cls: T, _: Any) -> T:
         # Fix for pydantic to support generic types (expressions like `SignatureT[bool]`)
         return cls
+
+
+class SignatureWithDefaultValue(Signature[T]):
+    default_value: T
 
 
 class ActionConfig(Generic[T], ImmutableEvolvableModel, ActionConfigT[T]):

--- a/orinoco/helpers.py
+++ b/orinoco/helpers.py
@@ -30,3 +30,12 @@ def extract_type(
         dtype, annotation, *tags = get_args(value)  # first two parameters - (type, annotation)
         return dtype, annotation, set(tags)
     return value, None, set()
+
+
+def compose(*functions):
+    def inner(arg):
+        for f in functions:
+            arg = f(arg)
+        return arg
+
+    return inner

--- a/orinoco/loop.py
+++ b/orinoco/loop.py
@@ -148,14 +148,12 @@ class For(BaseLoop):
         for iteration_value in self.method(action_data):
             loop_action_data = self.action.run(action_data.evolve(**{self.iterating_key: iteration_value}))
             if self.aggregated_field:
-                value_to_aggregate = action_data.get(self.aggregated_field)
+                value_to_aggregate = loop_action_data.get(self.aggregated_field)
                 if value_to_aggregate is not None or (not self.skip_none_for_aggregated_field):
                     aggregated_values.append(value_to_aggregate)
 
         if self.aggregated_field:
-            return loop_action_data.evolve(
-                **{self.aggregated_field_new_name or self.aggregated_field: aggregated_values}
-            )
+            return action_data.evolve(**{self.aggregated_field_new_name or self.aggregated_field: aggregated_values})
         return action_data
 
 

--- a/orinoco/transformation.py
+++ b/orinoco/transformation.py
@@ -93,13 +93,7 @@ class RenameActionField(Transformation):
         self.new_key = new_key
 
     def transform(self, action_data: ActionDataT) -> ActionDataT:
-        new_data = []
-        for signature, value in action_data.data:
-            if signature.key == self.key:
-                new_data.append((signature.evolve_self(key=self.new_key), value))
-            else:
-                new_data.append((signature, value))
-        return action_data.evolve_self(data=new_data)
+        return action_data.rename(key=self.key, new_key=self.new_key)
 
 
 class WithoutFields(Transformation):

--- a/orinoco/typed_action.py
+++ b/orinoco/typed_action.py
@@ -44,6 +44,22 @@ class TypedBase(Generic[T], Action, ABC):
         self.config = self.config.evolve_self(OUTPUT=Signature(key=key, type_=type_))
         return self
 
+    def input_as(self: TypedBaseT, **keys: str) -> TypedBaseT:
+        """
+        Mutable change of the input signature of the action.
+
+        Format:
+          new_key_name=old_key_name
+        """
+
+        self.config = self.config.evolve_self(
+            INPUT={
+                old_key: signature.evolve_self(key=keys.get(old_key, old_key))
+                for old_key, signature in self.config.INPUT.items()
+            }
+        )
+        return self
+
     @classmethod
     def _get_implicit_config(cls) -> ActionConfig[T]:
         annotations = cls.__call__.__annotations__

--- a/orinoco/types.py
+++ b/orinoco/types.py
@@ -30,6 +30,7 @@ class SignatureT(Generic[T], ImmutableEvolvableModelT, ABC):
     type_: Optional[Type[T]]
     tags: Set[str]
     key: Optional[str]
+    default_value: Any
 
     @abstractmethod
     def match(self, other_signature: "SignatureT[T]") -> bool:

--- a/orinoco/types.py
+++ b/orinoco/types.py
@@ -186,6 +186,10 @@ class ActionDataT(ImmutableEvolvableModelT, ABC):
     def with_new_execution_meta(self) -> "ActionDataT":
         pass
 
+    @abstractmethod
+    def rename(self, key: str, new_key: str) -> "ActionDataT":
+        pass
+
 
 class ActionT(ABC):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "orinoco"
-version = "1.0.8"
+version = "1.0.9"
 description = "Functional composable pipelines allowing clean separation of the business logic and its implementation"
 authors = ["Martin Vo <mvo@paysure.solutions>"]
 documentation = "https://orinoco.rtfd.io"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ import pytest
 from typing_extensions import Annotated
 
 from orinoco import config
+from orinoco.condition import Condition
 from orinoco.typed_action import TypedAction, TypedCondition
+from orinoco.types import ActionDataT
 
 
 @pytest.fixture
@@ -40,12 +42,30 @@ def success_after_attempts_typed_action() -> Type[TypedCondition]:
 
 
 @pytest.fixture
-def double_typed_action() -> TypedAction:
+def double_typed_action(double_typed_action_cls) -> TypedAction:
+    return double_typed_action_cls()
+
+
+@pytest.fixture
+def double_typed_action_cls() -> Type[TypedAction]:
     class Double(TypedAction):
         def __call__(self, x: int) -> Annotated[int, "double"]:
             return x * 2
 
-    return Double()
+    return Double
+
+
+@pytest.fixture
+def check_action_data_fields_action_cls() -> Type[Condition]:
+    class CheckFieldsInActionData(Condition):
+        def __init__(self, *fields: str):
+            super().__init__()
+            self.fields = fields
+
+        def _is_valid(self, action_data: ActionDataT) -> bool:
+            return set(self.fields) == {signature.key for signature in action_data.signatures}
+
+    return CheckFieldsInActionData
 
 
 @pytest.fixture

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -828,7 +828,6 @@ def test_for_loop_run_as_async():
 
 
 def test_guarded_action_set(double_typed_action_cls, check_action_data_fields_action_cls):
-
     action = (
         ActionSet(
             [

--- a/tests/test_typed_actions.py
+++ b/tests/test_typed_actions.py
@@ -268,3 +268,12 @@ def _test_condition(is_positive: TypedCondition) -> None:
 
     with pytest.raises(ConditionNotMet):
         is_positive.run_with_data(value=-10)
+
+
+def test_as_input(double_typed_action: TypedAction) -> None:
+    class MyNumber(int):
+        pass
+
+    result = double_typed_action.input_as(x="different_input").run_with_data(different_input=MyNumber(3))
+
+    assert result.get("double") == 6

--- a/tests/test_typed_actions.py
+++ b/tests/test_typed_actions.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass
+from typing import Optional, Generator
 
 import pytest
 from typing_extensions import Annotated
@@ -277,3 +278,33 @@ def test_as_input(double_typed_action: TypedAction) -> None:
     result = double_typed_action.input_as(x="different_input").run_with_data(different_input=MyNumber(3))
 
     assert result.get("double") == 6
+
+
+def test_default_inputs():
+    class WithDefaultAdd(TypedAction):
+        def __call__(self, x: int, y: int = 1) -> Annotated[int, "sum"]:
+            return x + y
+
+    assert WithDefaultAdd().run_with_data(x=1).get_by_key("sum") == 2
+    assert WithDefaultAdd().run_with_data(x=1, y=4).get_by_key("sum") == 5
+
+
+def test_optional_output():
+    class OptionalOutput(TypedAction):
+        def __call__(self, x: int) -> Annotated[Optional[int], "sum"]:
+            return x if x > 0 else None
+
+    assert OptionalOutput().run_with_data(x=1).get_by_key("sum") == 1
+    assert OptionalOutput().run_with_data(x=-1).get_by_key("sum") is None
+
+
+def test_generator_action():
+    class GeneratorAction(TypedAction):
+        def __call__(self, x: int) -> Annotated[Generator[int, None, None], "my_gen"]:
+            yield x
+            yield x + 1
+
+    gen = GeneratorAction().run_with_data(x=1).get("my_gen")
+    assert isinstance(gen, Generator)
+    assert next(gen) == 1
+    assert next(gen) == 2


### PR DESCRIPTION
-  As output for typed actions/condtions
-  As guarded for action set
- Guarded with `as_input` and `as_output`
- Input values with defaults
- Optional as output
- Allow generator and other complex types as output type